### PR TITLE
Request `Current` (with edits) `AVAsset` (video) Version instead of `…Original` in `AssetsManager.fetchAssetUrl`

### DIFF
--- a/ios/AssetsManager.mm
+++ b/ios/AssetsManager.mm
@@ -189,7 +189,7 @@
         }];
     } else if (asset.mediaType == PHAssetMediaTypeVideo) {
         PHVideoRequestOptions* options = [[PHVideoRequestOptions alloc] init];
-        [options setVersion:PHVideoRequestOptionsVersionOriginal];
+//        [options setVersion:PHVideoRequestOptionsVersionOriginal];
         [options setNetworkAccessAllowed:true];
         [[PHImageManager defaultManager] requestAVAssetForVideo:asset
                                                         options:options


### PR DESCRIPTION
Required to solve [Looky-2019](https://oneclicklife.youtrack.cloud/issue/Looky-2019/Nuzhno-sdelat-chtoby-gallereya-Luki-ponimala-redakturu-video-ot-sistemnoj-programmy-iPhone)